### PR TITLE
Fix for "finn-jobs" module and message splitting logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,32 +1,54 @@
-const { Client, Events, GatewayIntentBits } = require('discord.js');
+// Import necessary modules
+const { Client, Events, GatewayIntentBits, MessageFlags } = require('discord.js');
 const { token, channelID } = require('./config.json');
+const fetch = require('node-fetch');
+// eslint-disable-next-line no-undef
+globalThis.fetch = fetch;
 const getJobs = require('finn-jobb');
 
 // Create a new client instance
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 // When the client is ready, run this code (only once)
-client.once(Events.ClientReady, async c => {
+client.once(Events.ClientReady, async (c) => {
     console.log(`Ready! Logged in as ${c.user.tag}`);
 
-//reference to channel
-  const channel = await client.channels.fetch(channelID);
-  if (!channel) return console.error("Invalid channel ID in config.json");
+    // Reference to channel
+    const channel = await client.channels.fetch(channelID);
+    if (!channel) return console.error('Invalid channel ID in config.json');
 
-  // fetch job
-  const jobs = await getJobs();
+    // Fetch jobs
+    const jobs = await getJobs();
 
-  // create message
-  const message = jobs.map((job) => {
-    return `**${job.tekst}**
-    Location: ${job.lokasjon}
-    Date: ${job.dato}
-    Link: ${job.link}
-    `;
-  }).join('\n\n');
+    // Create messages
+    const messages = [];
+    let currentMessage = '';
 
-  // send message
-  client.channels.cache.get(channelID).send(message);
+    for (const job of jobs) {
+        const jobContent = `**${job.tekst}**\nLocation: ${job.lokasjon}\nDate: ${job.dato}\nLink: ${job.link}`;
+
+        if (currentMessage.length + jobContent.length > 2000) {
+            messages.push(currentMessage);
+            currentMessage = '';
+        }
+
+        currentMessage += `${jobContent}\n\n`;
+    }
+
+    if (currentMessage.length > 0) {
+        messages.push(currentMessage);
+    }
+
+    // Send messages
+    for (let i = 0; i < messages.length; i++) {
+        const message = messages[i];
+        await channel.send({
+            content: message,
+            flags: MessageFlags.SuppressEmbeds, // Disable link previews
+        });
+        console.log(`Sent message ${i + 1} of ${messages.length}`);
+    }
 });
 
+// Login with the token
 client.login(token);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "discord.js": "^14.10.2",
         "dotenv": "^16.0.3",
-        "finn-jobb": "^1.0.5"
+        "finn-jobb": "^1.0.5",
+        "node-fetch": "^2.6.9"
       },
       "devDependencies": {
         "eslint": "^8.39.0"
@@ -1033,6 +1034,25 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1393,6 +1413,11 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/ts-mixer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
@@ -1451,6 +1476,20 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "discord.js": "^14.10.2",
     "dotenv": "^16.0.3",
-    "finn-jobb": "^1.0.5"
+    "finn-jobb": "^1.0.5",
+    "node-fetch": "^2.6.9"
   },
   "devDependencies": {
     "eslint": "^8.39.0"


### PR DESCRIPTION
I've made some changes to address the issues encountered with the "finn-jobs" module and implemented a message splitting logic to comply with Discord's 2000 character limit. Here are the details of the changes:

1. Modified "finn-jobs" module issue:
- The "finn-jobs" module was not functioning properly, so I implemented a workaround to resolve the problem.
- Specifically, it seems that the module doesn't correctly import the "node-fetch" dependency, so I added a hack to ensure its availability.

2. Message splitting logic:
- To comply with Discord's 2000 character limit for messages, I implemented logic to split the message into smaller parts if it exceeds the limit.
- Each smaller message will contain a portion of the content, ensuring no message surpasses the character limit.
- These changes should address the issues you faced with the "finn-jobs" module and enable the proper functioning of the code.